### PR TITLE
fix error about API document

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Type: `function`
 
 Returns array of chartObjects separated by category
 
-### getChart([chart][, date], callback)
+### getChart([chartName], [date], callback)
 
 Type: `function`
 


### PR DESCRIPTION
`getChart([chart][, date], callback)` -> `getChart([chartName], [date], callback)`