### PR TITLE
Pull highest resolution cover for images

### DIFF
--- a/billboard-top-100.js
+++ b/billboard-top-100.js
@@ -159,11 +159,25 @@ function getCoverFromChartItem(chartItem, rank) {
 	var cover;
 	try {
 		if (rank == 1) {
-			cover = chartItem.children[1].children[3].children[5].attribs["data-src"];
+			if (typeof chartItem.children[1].children[3].children[5].attribs['data-srcset'] === "undefined"){
+				cover = chartItem.children[1].children[3].children[5].attribs.src;
+			} else if(chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ').length === 8){
+				cover = chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ')[6];
+			} else if(chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ').length === 6){
+				cover = chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ')[4];
+			}
 		} else {
 			for (var i = 0; i < chartItem.children[1].children[3].children.length; i++) {
 				if (chartItem.children[1].children[3].children[i].name === 'img') {
-					cover = chartItem.children[1].children[3].children[i].attribs['data-src'];
+					if (typeof chartItem.children[1].children[3].children[i].attribs['data-srcset'] === "undefined"){
+						cover = chartItem.children[1].children[3].children[i].attribs.src;
+					} else if(chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ').length === 8){
+						cover = chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ')[6];
+					} else if(chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ').length === 6){
+						cover = chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ')[4];
+					} else if (chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ').length === 4) {
+						cover = chartItem.children[1].children[3].children[i].attribs['data-srcset'].split(' ')[2];
+					}
 					break;
 				}
 			}

--- a/billboard-top-100.js
+++ b/billboard-top-100.js
@@ -160,7 +160,7 @@ function getCoverFromChartItem(chartItem, rank) {
 	try {
 		if (rank == 1) {
 			if (typeof chartItem.children[1].children[3].children[5].attribs['data-srcset'] === "undefined"){
-				cover = chartItem.children[1].children[3].children[5].attribs.src;
+				cover = chartItem.children[1].children[3].children[5].attribs["data-src"];;
 			} else if(chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ').length === 8){
 				cover = chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ')[6];
 			} else if(chartItem.children[1].children[3].children[5].attribs['data-srcset'].split(' ').length === 6){


### PR DESCRIPTION
This code will cycle through the results to find and send the highest resolution image from the source set. For example, the images have an src set like this.

```srcset="https://charts-static.billboard.com/img/2019/01/post-malone-tp6-53x53.jpg 53w, https://charts-static.billboard.com/img/2019/01/post-malone-tp6-106x106.jpg 106w, https://charts-static.billboard.com/img/2019/01/post-malone-tp6-87x87.jpg 87w, https://charts-static.billboard.com/img/2019/01/post-malone-tp6-174x174.jpg 174w"```

The code will try to pull the 174x174 if it exists, then 87x87 and so on. If there is a fail the cover is returned '' "

This also fixes some covers not returning the Billboard Top 100 placeholder ```https://assets.billboard.com/assets/1556291827/images/charts/bb-placeholder-new.jpg```